### PR TITLE
Optimize update-mapping.yml by removing apt update

### DIFF
--- a/.github/workflows/update-mapping.yml
+++ b/.github/workflows/update-mapping.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - name: Install XMLLint
         run: |
-          sudo apt update
           sudo apt install -y libxml2-utils
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
Removed unnecessary 'apt update' step from workflow.